### PR TITLE
buildSchematic: Replace consts in name

### DIFF
--- a/buildSchematic.js
+++ b/buildSchematic.js
@@ -136,6 +136,7 @@ function replaceConstsInConfig(data, compilerConsts) {
     return {
         info: {
             ...data.info,
+            name: replaceConsts(data.info.name, compilerConsts),
             description: data.info.description ? replaceConsts(data.info.description, compilerConsts) : undefined
         },
         tiles: {

--- a/buildSchematic.ts
+++ b/buildSchematic.ts
@@ -150,6 +150,7 @@ function replaceConstsInConfig(data:SchematicData, compilerConsts:CompilerConsts
 	return {
 		info: {
 			...data.info,
+			name: replaceConsts(data.info.name, compilerConsts),
 			description: data.info.description ? replaceConsts(data.info.description, compilerConsts) : undefined
 		},
 		tiles: {


### PR DESCRIPTION
This allows using consts in the schematic name.