### PR TITLE
Support schematic tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Usage: `msch build [schematic.json] (--output schematic.msch)`
 	"info": {
 		"name": "All Config Types",
 		"description": "testing schematic \nby $author",
+		"labels": ["test"],
 		"authors": ["BalaM314"],
 		"version": "1.0.0"
 	},

--- a/buildSchematic.js
+++ b/buildSchematic.js
@@ -150,7 +150,8 @@ function replaceConstsInConfig(data, icons) {
             info: {
                 ...data.info,
                 name: newName,
-                description: newDescription
+                description: newDescription,
+                labels: data.info.labels?.map(label => replaceConsts(label, compilerConsts))
             },
             tiles: {
                 grid: data.tiles.grid.map(row => row.map(name => replaceConsts(name, compilerConsts))),
@@ -181,6 +182,7 @@ export function buildSchematic(rawData, schema, icons) {
         const tags = {
             name: data.info.name,
             description: data.info.description,
+            labels: `[${data.info.labels?.map(label => JSON.stringify(label)).join(",") ?? ""}]`,
             ...data.info.tags
         };
         const tiles = data.tiles.grid.map((row, reversedY) => row.map((tile, x) => getBlockData(tile, data, x, height - reversedY - 1, schematicConsts)));

--- a/buildSchematic.js
+++ b/buildSchematic.js
@@ -175,14 +175,16 @@ export function buildSchematic(rawData, schema, icons) {
         let unvalidatedData = JSON.parse(rawData);
         const { valid, errors } = jsonschem.validate(unvalidatedData, schema);
         if (!valid)
-            throw new Error(`Schematic file is invalid: ${errors[0].stack}`);
+            crash(`Schematic file is invalid: ${errors[0].stack}`);
         const [data, schematicConsts] = replaceConstsInConfig(unvalidatedData, icons);
         const width = data.tiles.grid.map(row => row.length).sort().at(-1) ?? 0;
         const height = data.tiles.grid.length;
+        if (data.info.tags && "labels" in data.info.tags && data.info.labels)
+            crash(`Schematic file can only have data.info.labels or data.info.tags.labels, not both`);
         const tags = {
             name: data.info.name,
             description: data.info.description,
-            labels: `[${data.info.labels?.map(label => JSON.stringify(label)).join(",") ?? ""}]`,
+            labels: JSON.stringify(data.info.labels) ?? `[]`,
             ...data.info.tags
         };
         const tiles = data.tiles.grid.map((row, reversedY) => row.map((tile, x) => getBlockData(tile, data, x, height - reversedY - 1, schematicConsts)));

--- a/buildSchematic.ts
+++ b/buildSchematic.ts
@@ -195,16 +195,17 @@ export function buildSchematic(rawData:string, schema:Schema, icons: {
 	try {
 		let unvalidatedData:unknown = JSON.parse(rawData);
 		const {valid, errors} = jsonschem.validate(unvalidatedData, schema);
-		if(!valid) throw new Error(`Schematic file is invalid: ${errors[0].stack}`);
+		if(!valid) crash(`Schematic file is invalid: ${errors[0].stack}`);
 		const [data, schematicConsts] = replaceConstsInConfig(unvalidatedData as SchematicData, icons);
 
 		const width = data.tiles.grid.map(row => row.length).sort().at(-1) ?? 0;
 		const height = data.tiles.grid.length;
 		
+		if(data.info.tags && "labels" in data.info.tags && data.info.labels) crash(`Schematic file can only have data.info.labels or data.info.tags.labels, not both`);
 		const tags = {
 			name: data.info.name,
 			description: data.info.description!,
-			labels: `[${data.info.labels?.map(label => JSON.stringify(label)).join(",") ?? ""}]`,
+			labels: JSON.stringify(data.info.labels) ?? `[]`,
 			...data.info.tags
 		};
 		const tiles:(Tile|null)[][] = data.tiles.grid.map((row, reversedY) =>

--- a/buildSchematic.ts
+++ b/buildSchematic.ts
@@ -164,7 +164,8 @@ function replaceConstsInConfig(data:SchematicData, icons:Record<string, string>)
 		info: {
 			...data.info,
 			name: newName,
-			description: newDescription
+			description: newDescription,
+			labels: data.info.labels?.map(label => replaceConsts(label, compilerConsts))
 		},
 		tiles: {
 			grid: data.tiles.grid.map(row =>
@@ -203,6 +204,7 @@ export function buildSchematic(rawData:string, schema:Schema, icons: {
 		const tags = {
 			name: data.info.name,
 			description: data.info.description!,
+			labels: `[${data.info.labels?.map(label => JSON.stringify(label)).join(",") ?? ""}]`,
 			...data.info.tags
 		};
 		const tiles:(Tile|null)[][] = data.tiles.grid.map((row, reversedY) =>

--- a/docs/msch-v1.schema.json
+++ b/docs/msch-v1.schema.json
@@ -68,6 +68,12 @@
                 "description": {
                     "type": "string"
                 },
+                "labels": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/types.ts
+++ b/types.ts
@@ -5,6 +5,7 @@ export interface SchematicData {
 	info: {
 		name: string;
 		description?: string;
+		labels?: string[];
 		authors: string[];
 		version: string;
 		tags?: {


### PR DESCRIPTION
Schematic tags are stored in the `labels` tag. They can be quoted or unquoted, but, if they contain special characters like color markup, quotes are required, so it is simpler to always quote them.

Works with icons and color markup:

```json
"labels": [
	"a test tag",
	"icon $_silicon",
	"[red]$_metaglass[]",
	"[red]color[]"
],
```

![exciting-tags](https://github.com/user-attachments/assets/29e01593-21bf-49f1-80ff-c0fd680b80f7)
