### PR TITLE
Fix schematic width calculation

### DIFF
--- a/buildSchematic.js
+++ b/buildSchematic.js
@@ -179,7 +179,7 @@ export function buildSchematic(rawData, schema, icons) {
     if (!valid)
         fail(`Schematic file is invalid: ${errors[0].stack}`);
     const [data, schematicConsts] = replaceConstsInConfig(unvalidatedData, icons);
-    const width = data.tiles.grid.map(row => row.length).sort().at(-1) ?? 0;
+    const width = Math.max(0, ...data.tiles.grid.map(row => row.length));
     const height = data.tiles.grid.length;
     if (data.info.tags && "labels" in data.info.tags && data.info.labels)
         fail(`Schematic file can only have data.info.labels or data.info.tags.labels, not both`);

--- a/buildSchematic.ts
+++ b/buildSchematic.ts
@@ -204,7 +204,7 @@ export function buildSchematic(rawData:string, schema:Schema, icons: Record<stri
 	if(!valid) fail(`Schematic file is invalid: ${errors[0].stack}`);
 	const [data, schematicConsts] = replaceConstsInConfig(unvalidatedData as SchematicData, icons);
 
-	const width = data.tiles.grid.map(row => row.length).sort().at(-1) ?? 0;
+	const width = Math.max(0, ...data.tiles.grid.map(row => row.length));
 	const height = data.tiles.grid.length;
 	
 	if(data.info.tags && "labels" in data.info.tags && data.info.labels) fail(`Schematic file can only have data.info.labels or data.info.tags.labels, not both`);


### PR DESCRIPTION
`Array.prototype.sort()` [converts the elements to strings](https://tc39.es/ecma262/multipage/indexed-collections.html#sec-comparearrayelements) before sorting, so sorting an array of numbers then taking the last element does not give the greatest number when there are numbers with more than one digit.

This uses `Math.max` with spread syntax and zero in case the array is empty.